### PR TITLE
Optimize sr_no generation in ZRFI_INV_OUTST_02_07

### DIFF
--- a/ZRFI_INV_OUTST_02_07.abap
+++ b/ZRFI_INV_OUTST_02_07.abap
@@ -89,9 +89,9 @@ END-OF-SELECTION.
         CLEAR : ls_crm_os.
       ENDLOOP.
       CLEAR : lv_num.
+      SELECT SINGLE MAX( sr_no ) INTO lv_num FROM zcrm_os_integrat.
+
       LOOP AT gt_final INTO DATA(ls_final).
-        CLEAR : lv_num.
-        SELECT SINGLE MAX( sr_no ) INTO lv_num FROM zcrm_os_integrat.
         lv_num = lv_num + 1.
         ls_crm_os-sr_no = lv_num.
         ls_crm_os-manager = ls_final-manager.


### PR DESCRIPTION
## Summary
- Reduce repetitive database access by querying MAX(sr_no) once before the END-OF-SELECTION loop
- Increment cached sr_no for each entry inserted into zcrm_os_integrat

## Testing
- `abaplint ZRFI_INV_OUTST_02_07.abap` *(fails: command not found)*
- `npm install -g @abaplint/cli` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68932f2bbca4832896c7e9b336a4352c